### PR TITLE
Support python by using pythons' SslSocket instead of the standart socket

### DIFF
--- a/src/haxe/net/impl/SocketSys.hx
+++ b/src/haxe/net/impl/SocketSys.hx
@@ -21,7 +21,11 @@ class SocketSys extends Socket2 {
         var impl:Dynamic = null;
         if (secure) {
             #if (haxe_ver >= "3.3")
-                this.impl = new sys.ssl.Socket();
+				#if python
+                    this.impl = new python.net.SslSocket();
+				#else
+					this.impl = new sys.ssl.Socket();
+				#end
             #else
                 throw 'Not supporting secure sockets';
             #end


### PR DESCRIPTION
This should work perfectly once https://github.com/HaxeFoundation/haxe/pull/11256 is pushed. For the time being, add https://github.com/HaxeFoundation/haxe/pull/11256 into haxe by itself. This fixes all SSL-related bugs on Python.