### PR TITLE
Fix crash when creating an unencrypted WebSocket

### DIFF
--- a/src/haxe/net/WebSocketServer.hx
+++ b/src/haxe/net/WebSocketServer.hx
@@ -37,7 +37,7 @@ class WebSocketServer {
 	}
 	
 	public static function create(host:String, port:Int, maxConnections:Int, isSecure:Bool, isDebug:Bool) {
-		return new WebSocketServer(host, port, maxConnections, isSecure, isDebug);
+		return new WebSocketServer(host, port, maxConnections, isSecure ? true : null, isDebug);
 	}
 	
 	public function accept():WebSocket {


### PR DESCRIPTION
The `WebSocketServer` constructor checks if `isSecure` is different from `null`, which in turn causes it to be set if you pass `false` to the static `create` function. This change fixes this issue, while keeping the constructor the same to not break compatibility, if some code is calling it directly.