### PR TITLE
Fix an error when Chromium-based clients connect to a WebSocketServer

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,8 +1,8 @@
 {
   "name" : "colyseus-websocket",
   "description" : "WebSocket client aimed for all platforms",
-  "version" : "1.0.13",
-  "releasenote": "Fix crash when creating an unencrypted WebSocket",
+  "version" : "1.0.14",
+  "releasenote": "Fixed an error on HTML5 when a client connected to a WebSocketServer due to messages being masked by the server",
   "url" : "https://github.com/colyseus/colyseus-websocket-hx",
   "classPath" : "src",
   "license" : "Public",

--- a/src/haxe/net/impl/WebSocketGeneric.hx
+++ b/src/haxe/net/impl/WebSocketGeneric.hx
@@ -19,6 +19,7 @@ class WebSocketGeneric extends WebSocket {
     private var state:State = State.Handshake;
     public var debug:Bool = true;
     private var needHandleData:Bool = false;
+    public var shouldMaskFramesBeforeSending:Bool = true;
 
     function initialize(uri:String, protocols:Array<String> = null, origin:String = null, debug:Bool = true) {
         if (origin == null) origin = "http://127.0.0.1/";
@@ -81,6 +82,7 @@ class WebSocketGeneric extends WebSocket {
         websocket.state = State.ServerHandshake;
         websocket.httpHeader = alreadyRecieved;
         websocket.needHandleData = true;
+        websocket.shouldMaskFramesBeforeSending = false;
         return websocket;
     }
 
@@ -404,9 +406,9 @@ class WebSocketGeneric extends WebSocket {
         var out = new BytesRW();
 
         //Chrome: VM321:1 WebSocket connection to 'ws://localhost:8000/' failed: A server must not mask any frames that it sends to the client.
-        var isMasked = true; //false; // All clients messages must be masked: http://tools.ietf.org/html/rfc6455#section-5.1
+        // All clients messages must be masked: http://tools.ietf.org/html/rfc6455#section-5.1. Server messages should not be masked.
         var mask = generateMask();
-        var sizeMask = (isMasked ? 0x80 : 0x00);
+        var sizeMask = (shouldMaskFramesBeforeSending ? 0x80 : 0x00);
 
         out.writeByte(type.toInt() | (isFinal ? 0x80 : 0x00));
 
@@ -421,9 +423,9 @@ class WebSocketGeneric extends WebSocket {
             out.writeInt(data.length);
         }
 
-        if (isMasked) out.writeBytes(mask);
+        if (shouldMaskFramesBeforeSending) out.writeBytes(mask);
 
-        out.writeBytes(isMasked ? applyMask(data, mask) : data);
+        out.writeBytes(shouldMaskFramesBeforeSending ? applyMask(data, mask) : data);
         return out.readAllAvailableBytes();
     }
 }


### PR DESCRIPTION
Sending and receiving messages from the browser to a `WebSocketServer` would cause the following error on Chromium-based browsers:
`A server must not mask any frames that it sends to the client.`
This patch makes it so that only clients mask their messages, and not servers, as expected by the specification.
This IETF specification provides a detailed explanation: [https://datatracker.ietf.org/doc/html/rfc6455#section-5.1](https://datatracker.ietf.org/doc/html/rfc6455#section-5.1)